### PR TITLE
feat(ansible): default ansible_playbook_url -> use repo k3s playbook

### DIFF
--- a/tf-k8ssrv/opentofu/ansible/k3s/README.md
+++ b/tf-k8ssrv/opentofu/ansible/k3s/README.md
@@ -1,0 +1,34 @@
+k3s Ansible playbook
+====================
+
+Simple Ansible playbook to install k3s on a VM. It's intended to be used with the terraform module's ansible-pull runner (see opentofu/modules/vm).
+
+Usage
+-----
+
+The playbook runs on localhost (connection: local) and supports two roles via the `k3s_role` variable:
+
+- server: installs k3s server
+- agent: installs k3s agent and joins an existing server
+
+Example variables (can be passed via ansible-pull extra-vars or rendered in your repo):
+
+- k3s_role: "server"
+- k3s_version: "latest"         # or an explicit version like 'v1.27.4+k3s1'
+- k3s_channel: "stable"
+- k3s_token: "<pre-shared-token>"   # required for agents; recommended to set for servers too
+- k3s_server_url: "https://1.2.3.4:6443"  # required for agents
+
+Notes
+-----
+
+- The playbook uses the official k3s install script (https://get.k3s.io). For production or air-gapped installs consider using a vetted package or offline installation method.
+- The server writes kubeconfig to /etc/rancher/k3s/k3s.yaml with 0644 so tools can access it on the machine.
+- The playbook is minimal by design — feel free to extend with networking/CNI, ingress, and other components.
+
+Integration with terraform
+-------------------------
+
+Set `ansible_playbook_url` in the terraform module to point at the repo and path. Example (this repository):
+
+https://github.com/kszicsillag/Skalazhato.Tools.git#main#opentofu/ansible/k3s/site.yml

--- a/tf-k8ssrv/opentofu/ansible/k3s/site.yml
+++ b/tf-k8ssrv/opentofu/ansible/k3s/site.yml
@@ -1,0 +1,61 @@
+---
+# Simple Ansible playbook to install k3s (server or agent)
+# Designed to be used with ansible-pull from the terraform module's runner.
+
+- hosts: localhost
+  connection: local
+  become: true
+  vars:
+    k3s_version: "latest"     # or 'v1.27.4+k3s1', etc.
+    k3s_channel: "stable"     # k3s channel to use when installing via install script
+    k3s_role: "server"        # server or agent
+    k3s_token: ""             # pre-shared token for joining nodes (server must set this)
+    k3s_server_url: ""        # https://<server-ip>:6443 - required for agents
+    install_method: "script"  # 'script' for official install script, future methods possible
+
+  tasks:
+    - name: Ensure required packages are installed
+      apt:
+        name:
+          - curl
+          - iproute2
+        state: present
+        update_cache: yes
+
+    - name: Install k3s via official install script (server)
+      when: k3s_role == 'server' and install_method == 'script'
+      shell: |
+        curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ k3s_channel }} {{ 'INSTALL_K3S_VERSION=' + k3s_version if k3s_version != 'latest' else '' }} INSTALL_K3S_EXEC='--disable=traefik' sh -s - --write-kubeconfig-mode 644 {{ ('K3S_TOKEN=' + k3s_token) if k3s_token != '' else '' }}
+      args:
+        executable: /bin/bash
+
+    - name: Install k3s via official install script (agent)
+      when: k3s_role == 'agent' and install_method == 'script'
+      shell: |
+        curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ k3s_channel }} {{ 'INSTALL_K3S_VERSION=' + k3s_version if k3s_version != 'latest' else '' }} K3S_URL={{ k3s_server_url }} K3S_TOKEN={{ k3s_token }} sh -s -
+      args:
+        executable: /bin/bash
+
+    - name: Wait for kubeconfig to exist (server)
+      when: k3s_role == 'server'
+      wait_for:
+        path: /etc/rancher/k3s/k3s.yaml
+        timeout: 30
+
+    - name: Ensure kubectl (k3s kubectl) is callable via /usr/local/bin/kubectl
+      when: k3s_role == 'server'
+      file:
+        src: /usr/local/bin/k3s
+        dest: /usr/local/bin/kubectl
+        state: link
+
+    - name: Print join info (server)
+      when: k3s_role == 'server'
+      shell: |
+        echo "k3s token: $(cat /var/lib/rancher/k3s/server/node-token || true)"
+      register: join_info
+      changed_when: false
+
+    - name: Show join info debug
+      debug:
+        var: join_info.stdout_lines


### PR DESCRIPTION
Set default ansible_playbook_url in opentofu to point at the repository's k3s playbook (opentofu/ansible/k3s/site.yml). This makes ansible-pull easier to enable for new VMs.